### PR TITLE
Adds "visibility = hidden" to the album art swap

### DIFF
--- a/app.js
+++ b/app.js
@@ -304,6 +304,7 @@ App.updateCover = function(cover) {
         setTimeout(function() {
             currentAlbumCover.src = cover;
             newAlbumCover.classList.remove('active');
+            newAlbumCover.style["visibility"] = "hidden";
             newAlbumCover.src = '';
         }, 450);
     };


### PR DESCRIPTION
When swapping between the old and new album art, the old art appears broken for a split second. Unsure of why this happens, I've added an action to add `style="visibility: hidden;"` to the old art, to stop this broken image from displaying.